### PR TITLE
fix: correct placeholder used in xargs command

### DIFF
--- a/nuscenes_rosbag/README.md
+++ b/nuscenes_rosbag/README.md
@@ -88,7 +88,7 @@ python3 scripts/main.py
 - Run command to make rosbag for ROS2
 
 ```
-find $1 -name '*.bag' | xargs -n1 rosbags-convert {}
+find $1 -name '*.bag' -print0 | xargs -0 -I {} rosbags-convert {}
 ```
 
 ## Reference


### PR DESCRIPTION
after using command from README:
find $1 -name '*.bag' | xargs -n1 rosbags-convert {}
usage: rosbags-convert [-h] [--dst DST]
                       [--exclude-topic EXCLUDE_TOPICS | --include-topic INCLUDE_TOPICS]
                       src
rosbags-convert: error: argument src: {} should exist.
[...]
The error you're encountering indicates that the {} placeholder used in your xargs command is not being correctly replaced with the path of the .bag files found by find. This can happen due to the way xargs is being used or the specific syntax expected by rosbags-convert.